### PR TITLE
Remove unneeded bindgen default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ repository = "https://github.com/Better-Player/espeakng-sys"
 homepage = "https://github.com/Better-Player/espeakng-sys"
 readme = "README.md"
 
-[build-dependencies]
-bindgen = "0.59.1"
+[build-dependencies.bindgen]
+version = "0.59.1"
+default-features = false


### PR DESCRIPTION
I noticed my upstream project was pulling in `clap` and other command line crates, this is due to the [default features](https://github.com/rust-lang/rust-bindgen/blob/master/Cargo.toml#L73) of bindgen pulling it for the CLI version, however, this crate does not need them as it is simply a library.