### PR TITLE
Update headers to support output hooks for wavegen from espeak-ng 1.51

### DIFF
--- a/headers/espeak_ng.h
+++ b/headers/espeak_ng.h
@@ -77,6 +77,14 @@ typedef enum {
 	ENGENDER_NEUTRAL = 3,
 } espeak_ng_VOICE_GENDER;
 
+typedef struct
+{
+  void (*outputPhoSymbol)(char* pho_code,int pho_type);
+  void (*outputSilence)(short echo_tail);
+  void (*outputVoiced)(short sample);
+  void (*outputUnvoiced)(short sample);
+} espeak_ng_OUTPUT_HOOKS;
+
 /* eSpeak NG 1.49.0 */
 
 typedef struct espeak_ng_ERROR_CONTEXT_ *espeak_ng_ERROR_CONTEXT;
@@ -188,6 +196,12 @@ espeak_ng_CompilePhonemeDataPath(long rate,
                                  const char *destination_path,
                                  FILE *log,
                                  espeak_ng_ERROR_CONTEXT *context);
+                                 
+ESPEAK_NG_API espeak_ng_STATUS
+espeak_ng_SetOutputHooks(espeak_ng_OUTPUT_HOOKS* hooks);
+ESPEAK_NG_API espeak_ng_STATUS
+espeak_ng_SetConstF0(int f0);
+
 
 #ifdef __cplusplus
 }

--- a/headers/speak_lib.h
+++ b/headers/speak_lib.h
@@ -201,7 +201,7 @@ ESPEAK_API int espeak_Initialize(espeak_AUDIO_OUTPUT output, int buflength, cons
 
    buflength:  The length in mS of sound buffers passed to the SynthCallback function.
             Value=0 gives a default of 60mS.
-            This paramater is only used for AUDIO_OUTPUT_RETRIEVAL and AUDIO_OUTPUT_SYNCHRONOUS modes.
+            This parameter is only used for AUDIO_OUTPUT_RETRIEVAL and AUDIO_OUTPUT_SYNCHRONOUS modes.
 
    path: The directory which contains the espeak-ng-data directory, or NULL for the default location.
 
@@ -235,7 +235,7 @@ int SynthCallback(short *wav, int numsamples, espeak_EVENT *events);
       sometimes be zero (which does NOT indicate end of synthesis).
 
    events: an array of espeak_EVENT items which indicate word and sentence events, and
-      also the occurance if <mark> and <audio> elements within the text.  The list of
+      also the occurrence if <mark> and <audio> elements within the text.  The list of
       events is terminated by an event of type = 0.
 
 


### PR DESCRIPTION
This commit also includes some header documentation fixes.