### PR TITLE
Add clang-runtime feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/Better-Player/espeakng-sys"
 homepage = "https://github.com/Better-Player/espeakng-sys"
 readme = "README.md"
 
+[features]
+default = []
+clang-runtime = ["bindgen/runtime"]
+
 [build-dependencies.bindgen]
 version = "0.59.1"
 default-features = false

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ impl<T> PoisonlessLock<T> for Mutex<T> {
 
 ```
 
+## Crate features
+
+The `clang-runtime` features enables the `bindgen`'s `runtime` feature, which in turn is forwarded
+to the `runtime` feature in the [`clang-sys`](https://github.com/KyleMayes/clang-sys#dependencies) crate. 
+This enables dynamic linking of `libclang` at runtime. This
+feature flag is present to provide compatibility with other crates that require the `bindgen/runtime` feature.
+If you get the error ```'a `libclang` shared library is not loaded on this thread'```, try
+enabling the `clang-runtime` feature.
+
 ## License
 `espeakng-sys` is dual licensed under the Apache-2.0 and MIT license, at your discretion.
 Do note though, `espeak-ng` itself is licensed under the [GPL](http://www.gnu.org/licenses)


### PR DESCRIPTION
This allows using espeakng-sys in projects with dependencies that
require this feature
